### PR TITLE
Adding comparison for y input fixed #61

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,8 +15,13 @@ int main()
     cout << "Addition: " << x + y << endl;
     cout << "Subtraction: " << x - y << endl;
     cout << "Multiplication: " << x * y << endl;
-    cout << "Division: " << x / y << endl;
-    cout << "Remainder: " << x % y << endl;
+	if(y == 0){
+		cout << "Dividing by zero is not a number." << endl;
+	}
+	else{
+    		cout << "Division: " << x / y << endl;
+    		cout << "Remainder: " << x % y << endl;
+	}
     cout << "Square Root: " << sqrt(x) << endl;
     cout << "Square: " << pow(x, y) << endl;
 


### PR DESCRIPTION
Using a comparison to see if y = 0 and output desired error message instead of dividing by zero if true. Else run normal division.