### PR TITLE
Fix NAN error (closes #61)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,11 @@ int main()
     cout << "Addition: " << x + y << endl;
     cout << "Subtraction: " << x - y << endl;
     cout << "Multiplication: " << x * y << endl;
-    cout << "Division: " << x / y << endl;
+    if (y == 0) {
+        cout << "Division: " << x / y << endl;
+    } else {
+	cout << "Division: divide by Zero error" << endl;
+    }
     cout << "Remainder: " << x % y << endl;
     cout << "Square Root: " << sqrt(x) << endl;
     cout << "Square: " << pow(x, y) << endl;


### PR DESCRIPTION
fixes NaN error and replaces the divides section with a section telling the user a division by zero occured.